### PR TITLE
Single and double result for people display fixed

### DIFF
--- a/src/features/peopleList/PeoplePage/People/index.js
+++ b/src/features/peopleList/PeoplePage/People/index.js
@@ -34,7 +34,10 @@ const People = () => {
                 : `Search results for "${query}" (${totalResults})`
             }
           />
-          <CreditTiles>
+          <CreditTiles
+            single={people.length === 1}
+            double={people.length === 2}
+          >
             {people.map((person) => (
               <Credits
                 key={person.id}


### PR DESCRIPTION
Poprawione wyświetlanie pojedycznego i podwójnego wyniku wyszukiwania dla People. Analogiczne rozwiązanie do wcześniejszego problemu z Cast i Crew w MovieDetails.